### PR TITLE
Sleep when outputting 'y' for license acceptance.

### DIFF
--- a/react_native/Dockerfile
+++ b/react_native/Dockerfile
@@ -45,7 +45,7 @@ RUN cd /usr/local && \
 # Install android tools and system-image.
 
 ENV PATH $PATH:$ANDROID_HOME/tools:$ANDROID_HOME/platform-tools:$ANDROID_HOME/build-tools/23.0.1
-RUN echo "y" | android update sdk \
+RUN (while sleep 3; do echo "y"; done) | android update sdk \
     --no-ui \
     --force \
     --all \


### PR DESCRIPTION
Follows this SO answer: https://stackoverflow.com/a/41378051

The ususal `echo "y"` trick wasn't working when I ran the build just now.